### PR TITLE
Update NEP-488(Precompile for BLS12-381 curve operations). Support addition and multiplication only for G1/G2 subgroup.

### DIFF
--- a/neps/nep-0488.md
+++ b/neps/nep-0488.md
@@ -36,10 +36,10 @@ we must efficiently verify BLS signatures based on BLS12-381, as these are the s
 
 In this NEP, we propose to add the following host functions:
 
-- ***bls12381_p1_sum —*** computes the sum of signed points from $E(F_p)$ elliptic curve. This function is useful for aggregating public keys or signatures in the BLS signature scheme. It can be employed for simple addition in $E(F_p)$. It is kept separate from the `multiexp` function due to gas cost considerations.
-- ***bls12381_p2_sum —*** computes the sum of signed points from $E'(F_{p^2})$ elliptic curve. This function is useful for aggregating signatures or public keys in the BLS signature scheme. 
-- ***bls12381_p1_multiexp —*** calculates $\sum p_i s_i$ for points $p_i \in E(F_p)$ and scalars $s_i$. This operation can be used to multiply a group element by a scalar. 
-- ***bls12381_p2_multiexp —*** calculates $\sum p_i s_i$ for points $p_i \in E'(F_{p^2})$ and scalars $s_i$. 
+- ***bls12381_g1_sum —*** computes the sum of signed points from $G_1 \subset E(F_p)$. This function is useful for aggregating public keys or signatures in the BLS signature scheme. It can be employed for simple addition in $E(F_p)$. It is kept separate from the `multiexp` function due to gas cost considerations.
+- ***bls12381_g2_sum —*** computes the sum of signed points from $G_2 \subset E'(F_{p^2})$. This function is useful for aggregating signatures or public keys in the BLS signature scheme. 
+- ***bls12381_g1_multiexp —*** calculates $\sum p_i s_i$ for points $p_i \in G_1 \subset E(F_p)$ and scalars $s_i$. This operation can be used to multiply a group element by a scalar. 
+- ***bls12381_g2_multiexp —*** calculates $\sum p_i s_i$ for points $p_i \in G_2 \subset E'(F_{p^2})$ and scalars $s_i$. 
 - ***bls12381_map_fp_to_g1 —*** maps base field elements into $G_1$ points. It does not perform the mapping of byte strings into field elements.
 - ***bls12381_map_fp2_to_g2 —*** maps extension field elements into $G_2$ points.  This function does not perform the mapping of byte strings into extension field elements, which would be needed to efficiently map a message into a group element. We are not implementing the `hash_to_field`[^60] function because the latter can be executed within a contract and various hashing algorithms can be used within this function.
 - ***bls12381_p1_decompress —*** decompresses points from $E(F_p)$ provided in a compressed form. Certain protocols offer points on the curve in a compressed form (e.g., the light client updates in Ethereum 2.0), and decompression is a time-consuming operation. All the other functions in this NEP only accept decompressed points for simplicity and optimized gas consumption.
@@ -48,8 +48,8 @@ In this NEP, we propose to add the following host functions:
 
 Functions required for verifying BLS signatures[^59]:
 
-- bls12381_p1_sum
-- bls12381_p2_sum
+- bls12381_g1_sum
+- bls12381_g2_sum
 - bls12381_map_fp2_to_g2
 - bls12381_p1_decompress
 - bls12381_p2_decompress
@@ -57,8 +57,8 @@ Functions required for verifying BLS signatures[^59]:
 
 Functions required for verifying zkSNARKs:
 
-- bls12381_p1_sum
-- bls12381_p1_multiexp
+- bls12381_g1_sum
+- bls12381_g1_multiexp
 - bls12381_pairing_check
 
 Both zkSNARKs and BLS signatures can be implemented alternatively by swapping $G_1$ and $G_2$. 
@@ -524,29 +524,30 @@ For all functions, execution will terminate in the following cases:
 - The input length is not divisible by `item_size`.
 - The input is beyond memory bounds.
 
-#### bls12381_p1_sum
+#### bls12381_g1_sum
 
 ***Description:***
 
-The function calculates the sum of signed elements on the BLS12-381 curve. It accepts an arbitrary number of pairs $(s_i, p_i)$, where $p_i \in E(F_p)$ represents a point on the elliptic curve, and $s_i \in {0, 1}$ signifies the point's sign. The output is a single point from $E(F_p)$ equivalent to $\sum (-1)^{s_i}p_i$.
+The function calculates the sum of signed elements on the BLS12-381 curve. It accepts an arbitrary number of pairs $(s_i, p_i)$, where $p_i \in G_1 \subset E(F_p)$ represents a point on the elliptic curve, and $s_i \in {0, 1}$ signifies the point's sign. The output is a single point from $G_1 \subset E(F_p)$ equivalent to $\sum (-1)^{s_i}p_i$.
 
-The operations, including the $E(F_p)$ curve, points on the curve, multiplication by -1, and the addition operation, are detailed in the BLS12-381 Curve Specification section.
+The operations, including the $E(F_p)$ curve, $G_1$ subgroup, points on the curve, multiplication by -1, and the addition operation, are detailed in the BLS12-381 Curve Specification section.
 
-Note: This function accepts points from the entire curve and is not restricted to points in $G_1$.
+Note: This function accepts only points from $G_1$.
 
 ***Input:***
 
-The sequence of pairs $(s_i, p_i)$, where $p_i \in E(F_p)$ represents a point and $s_i \in {0, 1}$ denotes the sign. Each point is encoded in decompressed form as $(x\colon F_p, y\colon F_p)$, and the sign is encoded in one byte, taking only two allowed values: 0 or 1. Expect 97*k bytes as input, which are interpreted as byte concatenation of k slices, with each slice representing the point sign and the uncompressed point from $E(F_p)$. Further details are available in the Curve Points Encoding section.
+The sequence of pairs $(s_i, p_i)$, where $p_i \in G_1 \subset E(F_p)$ represents a point and $s_i \in {0, 1}$ denotes the sign. Each point is encoded in decompressed form as $(x\colon F_p, y\colon F_p)$, and the sign is encoded in one byte, taking only two allowed values: 0 or 1. Expect 97*k bytes as input, which are interpreted as byte concatenation of k slices, with each slice representing the point sign and the uncompressed point from $E(F_p)$. Further details are available in the Curve Points Encoding section.
 
 ***Output:*** 
 
 The ERROR_CODE is returned. 
 
 - ERROR_CODE = 0: the input is correct
-  - <ins>Output:</ins> 96 bytes represent one point $\in E(F_p)$ in its decompressed form. In case of an empty input, it outputs a point on infinity (refer to the Curve Points Encoding section for more details).
+  - <ins>Output:</ins> 96 bytes represent one point $\in G_1 \subset E(F_p)$ in its decompressed form. In case of an empty input, it outputs a point on infinity (refer to the Curve Points Encoding section for more details).
 - ERROR_CODE = 1:
   - Points or signs are incorrectly encoded (refer to Curve points encoded section).
   - Point is not on the curve.
+  - Point is not from $G_1$
 
 ***Test cases:***
 
@@ -555,13 +556,12 @@ The ERROR_CODE is returned.
 This section aims to verify the correctness of summing up two valid elements on the curve:
 
 - Utilize points on the curve with known addition results for comparison, such as tests from EIP-2537[^47],[^48].
-- Generate random points on the curve and verify the commutative property: P + Q = Q + P.
+- Generate random points on the curve from $G_1$ and verify the commutative property: P + Q = Q + P.
 - Validate that the sum of random points from $G_1$ remains in $G_1$.
-- Generate random points on the curve and use another library to cross-check the results.
+- Generate random points on the curve from $G_1$ and use another library to cross-check the results.
 
 Edge cases:
 
-- Points not from $G_1$.
 - $\mathcal{O} + \mathcal{O} = \mathcal{O}$.
 - $P + \mathcal{O} = \mathcal{O} + P = P$.
 - $P + (-P) = (-P) + P = \mathcal{O}$.
@@ -580,7 +580,6 @@ This section aims to validate the correctness of point inversion:
 
 Edge cases:
 
-- Point not from $G_1$
 - $-\mathcal{O}$
 
 <ins>Tests for incorrect data</ins>
@@ -593,6 +592,7 @@ This section aims to validate the handling of incorrect input data:
 - Erroneous coding of field elements resulting in a correct element on the curve modulo p.
 - Erroneous coding of field elements with an incorrect extra bit in the decompressed encoding.
 - Point not on the curve.
+- Point not from $G_1$.
 - Incorrect encoding of the point at infinity.
 - Input is beyond memory bounds.
 
@@ -614,27 +614,27 @@ Edge cases:
 ***Annotation:***
 
 ```rust
-pub fn bls12381_p1_sum(&mut self, 
+pub fn bls12381_g1_sum(&mut self, 
                        value_len: u64, 
                        value_ptr: u64, 
                        register_id: u64) -> Result<u64>;
 ```
 
-#### bls12381_p2_sum
+#### bls12381_g2_sum
 
 ***Description:***
 
-The function computes the sum of the signed elements on the BLS12-381 curve. It accepts an arbitrary number of pairs $(s_i, p_i)$, where $p_i \in E'(F_{p^2})$ represents a point on the elliptic curve and $s_i \in {0, 1}$ is the point's sign. The output is a single point from $E'(F_{p^2})$ equal to $\sum (-1)^{s_i}p_i$.
+The function computes the sum of the signed elements on the BLS12-381 curve. It accepts an arbitrary number of pairs $(s_i, p_i)$, where $p_i \in G_2 \subset E'(F_{p^2})$ represents a point on the elliptic curve and $s_i \in {0, 1}$ is the point's sign. The output is a single point from $G_2 \subset E'(F_{p^2})$ equal to $\sum (-1)^{s_i}p_i$.
 
-The $E'(F_{p^2})$ curve, the points on the curve, the multiplication by -1, and the addition operation are all defined in the BLS12-381 Curve Specification section.
+The $E'(F_{p^2})$ curve, $G_2$ subgroup, the points on the curve, the multiplication by -1, and the addition operation are all defined in the BLS12-381 Curve Specification section.
 
-Note: The function accepts any points on the curve and is not limited to points in $G_2$.
+Note: The function accepts only points from $G_2$.
 
 ***Input:*** 
 
-The sequence of pairs $(s_i, p_i)$, where $p_i \in E'(F_{p^2})$ is point and $s_i \in \textbraceleft 0, 1 \textbraceright$  represents a sign.  
+The sequence of pairs $(s_i, p_i)$, where $p_i \in G_2 \subset E'(F_{p^2})$ is point and $s_i \in \textbraceleft 0, 1 \textbraceright$  represents a sign.  
 Each point is encoded in decompressed form as $(x: F_{p^2}, y: F_{p^2})$, and the sign is encoded in one byte. The expected input size is 193*k bytes, interpreted as a byte concatenation of k slices, 
-each slice representing the point sign alongside the uncompressed point from $E'(F_{p^2})$. 
+each slice representing the point sign alongside the uncompressed point from $G_2 \subset E'(F_{p^2})$. 
 More details are available in the Curve Points Encoding section.
 
 ***Output:***
@@ -642,29 +642,30 @@ More details are available in the Curve Points Encoding section.
 The ERROR_CODE is returned.
 
 - ERROR_CODE = 0: the input is correct
-  - <ins>Output:</ins> 192 bytes represent one point $\in E'(F_{p^2})$ in its decompressed form. In case of an empty input, it outputs the point at infinity (refer to the Curve Points Encoding section for more details).
+  - <ins>Output:</ins> 192 bytes represent one point $\in G_2 \subset E'(F_{p^2})$ in its decompressed form. In case of an empty input, it outputs the point at infinity (refer to the Curve Points Encoding section for more details).
 - ERROR_CODE = 1:
   - Points or signs are incorrectly encoded (refer to Curve points encoded section).
   - Point is not on the curve.
+  - Point is not from $G_2$.
 
 ***Test cases:***
 
-The test cases are identical to those of `bls12381_p1_sum`, with the only alteration being the substitution of points from $G_1$ and $E(F_p)$ with points from $G_2$ and $E'(F_{p^2})$.
+The test cases are identical to those of `bls12381_g1_sum`, with the only alteration being the substitution of points from $G_1$ and $E(F_p)$ with points from $G_2$ and $E'(F_{p^2})$.
 
 ***Annotation:***
 
 ```rust
-pub fn bls12381_p2_sum(&mut self, 
+pub fn bls12381_g2_sum(&mut self, 
                        value_len: u64, 
                        value_ptr: u64, 
                        register_id: u64) -> Result<u64>;
 ```
 
-#### ***bls12381_p1_multiexp***
+#### ***bls12381_g1_multiexp***
 
 ***Description:***
 
-The function accepts a list of pairs $(p_i, s_i)$, where $p_i \in E(F_p)$ represents a point on the curve, and $s_i \in \mathbb{N}_0$ denotes a scalar. It calculates $\sum s_i \cdot p_i$.
+The function accepts a list of pairs $(p_i, s_i)$, where $p_i \in G_1 \subset E(F_p)$ represents a point on the curve, and $s_i \in \mathbb{N}_0$ denotes a scalar. It calculates $\sum s_i \cdot p_i$.
 
 The scalar multiplication operation signifies the addition of that point a scalar number of times:
 
@@ -672,25 +673,26 @@ $$
 s \cdot p = \underbrace{p + p + \ldots + p}_{s}
 $$
 
-The $E(F_p)$ curve, points on the curve, and the addition operation are defined in the BLS12-381 Curve Specification section.
+The $E(F_p)$ curve, $G_1$ subgroup, points on the curve, and the addition operation are defined in the BLS12-381 Curve Specification section.
 
 Please note:
 
-- The function accepts any points on the curve, not solely from $G_1$.
+- The function accepts only points from $G_1$.
 - The scalar is an arbitrary unsigned integer and can exceed the group order.
 - To enhance gas efficiency, the Pippenger’s algorithm[^25] can be utilized.
 
-***Input:*** The sequence of pairs $(p_i, s_i)$, where $p_i \in E(F_p)$ represents a point on the curve, and $s_i \in \mathbb{N}_0$ is a scalar. The expected input size is 128*k bytes, interpreted as byte concatenation of k slices. Each slice comprises the concatenation of an uncompressed point from $E(F_p)$— 96 bytes, along with a scalar— 32 bytes. Further details are available in the Curve Points Encoding section.
+***Input:*** The sequence of pairs $(p_i, s_i)$, where $p_i \in G_1 \subset E(F_p)$ represents a point on the curve, and $s_i \in \mathbb{N}_0$ is a scalar. The expected input size is 128*k bytes, interpreted as byte concatenation of k slices. Each slice comprises the concatenation of an uncompressed point from $G_1 \subset E(F_p)$— 96 bytes, along with a scalar— 32 bytes. Further details are available in the Curve Points Encoding section.
 
 ***Output:***
 
 The ERROR_CODE is returned.
 
 - ERROR_CODE = 0: the input is correct
-  - <ins>Output:</ins> 96 bytes represent one point $\in E(F_p)$ in its decompressed form. In case of an empty input, it outputs the point at infinity (refer to the Curve Points Encoding section for more details).
+  - <ins>Output:</ins> 96 bytes represent one point $\in G_1 \subset E(F_p)$ in its decompressed form. In case of an empty input, it outputs the point at infinity (refer to the Curve Points Encoding section for more details).
 - ERROR_CODE = 1:
   - Points are incorrectly encoded (refer to Curve points encoded section).
   - Point is not on the curve.
+  - Point is not from $G_1$
 
 ***Test cases:***
 
@@ -715,7 +717,7 @@ Edge cases:
 
 <ins>Tests for sum of two points</ins>
 
-These are identical test cases to those in the `bls12381_p1_sum` section.
+These are identical test cases to those in the `bls12381_g1_sum` section.
 
 - Generate random points P and Q, then compare the results with the sum function.
 
@@ -730,17 +732,18 @@ These are identical test cases to those in the `bls12381_p1_sum` section.
 - Tests with known answers from EIP-2537[^47],[^48]
 - Random number of points, scalars, and points:
   - Check with results from another library.
-  - Check with raw implementation based on the sum function and the double-and-add algorithm.- Empty input
+  - Check with raw implementation based on the sum function and the double-and-add algorithm.
+- Empty input
 - Maximum number of scalars and points.
 
 <ins>Tests for error cases</ins>
 
-The same test cases as those in the `bls12381_p1_sum` section will be applied.
+The same test cases as those in the `bls12381_g1_sum` section will be applied.
 
 ***Annotation:***
 
 ```rust
-pub fn bls12381_p1_multiexp(
+pub fn bls12381_g1_multiexp(
         &mut self,
         value_len: u64,
         value_ptr: u64,
@@ -748,11 +751,11 @@ pub fn bls12381_p1_multiexp(
 ) -> Result<u64>;
 ```
 
-#### ***bls12381_p2_multiexp***
+#### ***bls12381_g2_multiexp***
 
 ***Description:***
 
-The function takes a list of pairs $(p_i, s_i)$ as input, where $p_i \in E'(F_{p^2})$ represents a point on the curve, and $s_i \in \mathbb{N}_0$ denotes a scalar. The function computes $\sum s_i \cdot p_i$.
+The function takes a list of pairs $(p_i, s_i)$ as input, where $p_i \in G_2 \subset E'(F_{p^2})$ represents a point on the curve, and $s_i \in \mathbb{N}_0$ denotes a scalar. The function computes $\sum s_i \cdot p_i$.
 
 This scalar multiplication operation involves adding the point $p$ to itself a specified number of times:
 
@@ -760,36 +763,37 @@ $$
 s \cdot p = \underbrace{p + p + \ldots + p}_{s}
 $$
 
-The $E'(F_{p^2})$ curve, points on the curve, and the addition operation are defined in the BLS12-381 Curve Specification section.
+The $E'(F_{p^2})$ curve, $G_2$ subgroup, points on the curve, and the addition operation are defined in the BLS12-381 Curve Specification section.
 
 Please note:
 
-- The function accepts any points on the curve, not solely from $G_2$.
+- The function accepts only points from $G_2$.
 - The scalar is an arbitrary unsigned integer and can exceed the group order.
 - To enhance gas efficiency, the Pippenger’s algorithm[^25] can be utilized.
 
-***Input:*** the sequence of pairs $(p_i, s_i)$, where $p_i \in E'(F_{p^2})$ is a point on the curve and $s_i \in \mathbb{N}_0$ is a scalar. 
+***Input:*** the sequence of pairs $(p_i, s_i)$, where $p_i \in G_2 \subset E'(F_{p^2})$ is a point on the curve and $s_i \in \mathbb{N}_0$ is a scalar. 
 
-The expected input size is `224*k` bytes, interpreted as the byte concatenation of `k` slices. Each slice is the concatenation of an uncompressed point from $E'(F_{p^2})$ — `192` bytes and a scalar — `32` bytes. More details are in the Curve Points Encoding section.
+The expected input size is `224*k` bytes, interpreted as the byte concatenation of `k` slices. Each slice is the concatenation of an uncompressed point from $G_2 \subset E'(F_{p^2})$ — `192` bytes and a scalar — `32` bytes. More details are in the Curve Points Encoding section.
 
 ***Output:*** 
 
 The ERROR_CODE is returned.
 
 - ERROR_CODE = 0: the input is correct
-  - <ins>Output:</ins> 192 bytes represent one point $\in E'(F_{p^2})$ in its decompressed form. In case of an empty input, it outputs the point at infinity (refer to the Curve Points Encoding section for more details).
+  - <ins>Output:</ins> 192 bytes represent one point $\in G_2 \subset E'(F_{p^2})$ in its decompressed form. In case of an empty input, it outputs the point at infinity (refer to the Curve Points Encoding section for more details).
 - ERROR_CODE = 1:
   - Points are incorrectly encoded (refer to Curve points encoded section).
   - Point is not on the curve.
+  - Point is not in $G_2$ subgroup.
 
 ***Test cases:***
 
-The test cases are identical to those for `bls12381_p1_multiexp`, except that the points from $G_1$ and $E(F_p)$ are replaced with points from $G_2$ and $E'(F_{p^2})$
+The test cases are identical to those for `bls12381_g1_multiexp`, except that the points from $G_1$ and $E(F_p)$ are replaced with points from $G_2$ and $E'(F_{p^2})$
 
 ***Annotation:***
 
 ```rust
-pub fn bls12381_p2_multiexp(
+pub fn bls12381_g2_multiexp(
         &mut self,
         value_len: u64,
         value_ptr: u64,


### PR DESCRIPTION
In the original NEP-488, we supported addition and multiplication operations for any valid points on elliptic curves.

In this PR, I have restricted the input for bls_p1/p2_sum and bls_p1/p2_multiexp to elements from the G1/G2 subgroups only.

In all cases where we need these functions, support for elements from G1/G2 is sufficient. However, verifying that a point belongs to a subgroup is a costly operation, and users cannot ensure within a contract that a point is from G1/G2. By implementing this restriction, we can prevent certain errors.

Additionally, in the future, we will have more flexibility in choosing algorithms and libraries. If a library assumes that points are in the subgroup, we will be able to use it without issue.